### PR TITLE
Update Parsing.cpp

### DIFF
--- a/libraries/WebServer/src/Parsing.cpp
+++ b/libraries/WebServer/src/Parsing.cpp
@@ -458,7 +458,23 @@ readfile:
               }
 
               uint8_t endBuf[boundary.length()];
-              client.readBytes(endBuf, boundary.length());
+              uint32_t i = 0;
+              while(i < boundary.length()){
+								argByte = _uploadReadByte(client);
+                if(argByte < 0) return _parseFormUploadAborted();
+                if ((char)argByte == 0x0D){
+									_uploadWriteByte(0x0D);
+									_uploadWriteByte(0x0A);
+									_uploadWriteByte((uint8_t)('-'));
+									_uploadWriteByte((uint8_t)('-'));
+									uint32_t j = 0;
+									while(j < i){
+										_uploadWriteByte(endBuf[j++]);
+									}
+									goto readfile;
+								}
+								endBuf[i++] = (uint8_t)argByte;
+							}
 
               if (strstr((const char*)endBuf, boundary.c_str()) != NULL){
                 if(_currentHandler && _currentHandler->canUpload(_currentUri))


### PR DESCRIPTION
When uploading TLS cert files the end of file "-----END CERTIFICATE-----" (or any kind of file with the sequence "CRLF--") is taken as posible end boundary. Then it is compared to the start boundary string. As it is expected, comparison turns to be false, and the whole end boundary string is put to _currentUpload->buf through _uploadWriteByte(). Here you have the problem: if you read boundary.length() bytes from HTTP request and you have some of the actual end boundary bytes in it, when you put all those bytes into _currentUpload->buf you are making a mistake. You will miss the actual end boundary string because some of those bytes were put in _currentUpload->buf.